### PR TITLE
Add Makefile and requirements.txt for streamlined setup and execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+# Install Python dependencies
+install-deps:
+    pip install -r requirements.txt
+
 # Command to start the backend
-start-backend:
+start-backend: install-deps
     python Backend/app.py
 
 # Placeholder for starting the frontend
@@ -7,7 +11,6 @@ start-frontend:
     @echo "Frontend setup not implemented yet."
 
 # Command to start both backend and frontend
-start:
-    make start-backend
+start: start-backend
     # Uncomment the line below when the frontend is ready
     # make start-frontend

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# Command to start the backend
+start-backend:
+    python Backend/app.py
+
+# Placeholder for starting the frontend
+start-frontend:
+    @echo "Frontend setup not implemented yet."
+
+# Command to start both backend and frontend
+start:
+    make start-backend
+    # Uncomment the line below when the frontend is ready
+    # make start-frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask_cors


### PR DESCRIPTION
This PR introduces two key files to simplify the development workflow:

1. **Makefile**:
   - Provides centralized commands for setting up and running the project.
   - Includes the following targets:
     - `install-deps`: Installs Python dependencies from requirements.txt.
     - `start-backend`: Installs dependencies and starts the backend.
     - `start-frontend`: Placeholder for starting the frontend (to be implemented later).
     - `start`: Combines both backend and frontend startup commands (frontend currently commented out).

2. **requirements.txt**:
   - Lists the Python dependencies (`flask` and `flask_cors`) required for the backend.

### Usage:
- Install dependencies: `make install-deps`
- Start the backend: `make start-backend`
- Start the entire project: `make start`

These additions ensure a consistent and easy setup process for all contributors.