### PR TITLE
Fix Makefile indentation issue to ensure proper execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # Install Python dependencies
 install-deps:
-    pip install -r requirements.txt
+	pip install -r requirements.txt
 
 # Command to start the backend
 start-backend: install-deps
-    python Backend/app.py
+	python Backend/app.py
 
 # Placeholder for starting the frontend
 start-frontend:
-    @echo "Frontend setup not implemented yet."
+	@echo "Frontend setup not implemented yet."
 
 # Command to start both backend and frontend
 start: start-backend
-    # Uncomment the line below when the frontend is ready
-    # make start-frontend
+	# Uncomment the line below when the frontend is ready
+	# make start-frontend


### PR DESCRIPTION
This PR resolves an issue in the Makefile where commands were not properly indented with tabs, causing a missing separator error. All commands under targets (install-deps, start-backend, etc.) are now correctly indented with tabs, ensuring compatibility with make.
