### PR TITLE
fix: Make dependency installation optional in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@
 install-deps:
 	pip install -r requirements.txt
 
-# Command to start the backend
-start-backend: install-deps
+# Command to start the backend with optional dependency installation
+# Usage: make start-backend DEPS=true
+start-backend:
+	@if [ "$(DEPS)" = "true" ]; then \
+		echo "Installing dependencies..."; \
+		pip install -r requirements.txt; \
+	fi
 	python Backend/app.py
 
 # Placeholder for starting the frontend


### PR DESCRIPTION
Summary
Modified the `start-backend` target in the Makefile to make dependency
installation optional, improving developer experience by allowing faster
startup when dependencies are already installed.

- **Modified `start-backend` target**: Now runs without dependency
  installation by default
  - **Added optional dependency installation**: Use `make start-backend
    DEPS=true` to install dependencies before starting
    - **Improved developer workflow**: Developers can now start the
      backend immediately if dependencies are already installed

      ## Usage
      ```bash
      # Start backend without installing dependencies (default)
      make start-backend

      # Start backend with dependency installation
      make start-backend DEPS=true
      ```

      ## Benefits
      - **Faster development cycles**: No need to wait for dependency
	installation on subsequent runs
	- **Flexible workflow**: Developers can choose when to install
	  dependencies
	  - **Backward compatibility**: Original behavior still
	    available with `DEPS=true` parameter

	    ## Testing
	    - ✅ `make start-backend` starts backend without installing
	      deps
	      - ✅ `make start-backend DEPS=true` installs deps and
		starts backend
		- ✅ Existing `make start` command continues to work as
		  expected

## Summary by Sourcery

Make the Makefile start-backend target skip dependency installation by default and add an optional DEPS flag to install dependencies when needed

Enhancements:
- Remove mandatory dependency installation from start-backend target
- Add DEPS=true option to control when dependencies are installed before starting the backend